### PR TITLE
[#22] NavigationController Extension 생성

### DIFF
--- a/popo/popo/Sources/Extension/UINavigationController+Extension.swift
+++ b/popo/popo/Sources/Extension/UINavigationController+Extension.swift
@@ -9,45 +9,81 @@ import UIKit
 
 extension UINavigationController {
     
-    // MARK: - Functions
+    // MARK: - 투명
     
-    // navi bar 숨기기
-    func hideNavigationBar() {
-        // navigation bar 투명화
-        navigationBar.setBackgroundImage(UIImage(), for: .default)
-        navigationBar.shadowImage = UIImage()
-        navigationBar.isTranslucent = true
-        
-        // navigation bar 숨기기
-        isNavigationBarHidden = true
+    func initTransparentNavBar() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        self.navigationBar.standardAppearance = appearance
+        self.navigationBar.scrollEdgeAppearance = appearance
     }
     
-    // back button이 있는 navi bar
-    func initializeNavigationBarWithBackButton(navigationItem: UINavigationItem?) {
-        isNavigationBarHidden = false
-        navigationBar.barTintColor = UIColor.white
-        navigationBar.shadowImage = UIImage()
-        navigationBar.isTranslucent = false
+    // MARK: - 뒤로가기 버튼
+    
+    func initWithBackButton() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        appearance.initBackButtonAppearance()
         
-        // back button 설정
-        let backButton = UIBarButtonItem(image: UIImage(systemName: "chevron.backward"), style: .plain, target: self, action: #selector(touchBackButton))
-        backButton.tintColor = UIColor.black
-
-        navigationItem?.leftBarButtonItem = backButton
+        self.navigationBar.standardAppearance = appearance
+        self.navigationBar.scrollEdgeAppearance = appearance
+        self.navigationBar.tintColor = .black
     }
+    
+    // MARK: - 뒤로가기 버튼 + 완료 버튼
+    
+    func initWithBackAndDoneButton(navigationItem: UINavigationItem?, doneButtonClosure: Selector) {
+        initWithBackButton()
+        
+        // done Button
+        let doneButton = UIBarButtonItem(title: "완료", style: .done, target: self.topViewController, action: doneButtonClosure)
+        navigationItem?.rightBarButtonItem = doneButton
+    }
+    
+    // MARK: - 커스텀 버튼 1개
+    
+    func initWithOneCustomButtons(navigationItem: UINavigationItem?, firstButtonImage: UIImage, firstButtonClosure: Selector) {
+        initWithBackButton()
+        
+        let firstButton = UIBarButtonItem(image: firstButtonImage, style: .plain, target: self.topViewController, action: firstButtonClosure)
+        navigationItem?.rightBarButtonItem = firstButton
+        
+    }
+    
+    // MARK: - 커스텀 버튼 2개
+    
+    func initWithTwoCustomButtons(navigationItem: UINavigationItem?, firstButtonImage: UIImage, secondButtonImage: UIImage, firstButtonClosure: Selector, secondButtonClosure: Selector) {
+        initWithBackButton()
+        
+        let firstButton = UIBarButtonItem(image: firstButtonImage, style: .plain, target: self.topViewController, action: firstButtonClosure)
+        let secondButton = UIBarButtonItem(image: secondButtonImage, style: .plain, target: self.topViewController, action: secondButtonClosure)
+        navigationItem?.rightBarButtonItems = [firstButton, secondButton]
+        
+    }
+    
+    // MARK: - @objc function
     
     @objc func touchBackButton() {
         popViewController(animated: true)
     }
+}
+
+extension UINavigationBarAppearance {
     
-    // back button이 없는 navi bar
-    func initializeNavigationBarWithoutBackButton(navigationItem: UINavigationItem?) {
-        isNavigationBarHidden = false
-        navigationBar.barTintColor = UIColor.white
-        navigationBar.shadowImage = UIImage()
-        navigationBar.isTranslucent = false
-        
-        // back button 숨기기
-        navigationItem?.hidesBackButton = true
+    func initBackButtonAppearance() {
+        // back button image
+        var backButtonImage: UIImage? {
+            return UIImage(systemName: "chevron.left")?.withAlignmentRectInsets(UIEdgeInsets(top: 0.0, left: -12.0, bottom: -5.0, right: 0.0))
+        }
+        // back button appearance
+        var backButtonAppearance: UIBarButtonItemAppearance {
+            let backButtonAppearance = UIBarButtonItemAppearance()
+            // backButton하단에 표출되는 text를 안보이게 설정
+            backButtonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.clear, .font: UIFont.systemFont(ofSize: 0.0)]
+
+            return backButtonAppearance
+        }
+        self.setBackIndicatorImage(backButtonImage, transitionMaskImage: backButtonImage)
+        self.backButtonAppearance = backButtonAppearance
     }
 }

--- a/popo/popo/Sources/ViewController/Login/LoginMethodViewController.swift
+++ b/popo/popo/Sources/ViewController/Login/LoginMethodViewController.swift
@@ -36,8 +36,7 @@ class LoginMethodViewController: UIViewController {
     }
     
     private func initNavigationBar() {
-       // self.navigationController?.initializeNavigationBarWithoutBackButton(navigationItem: self.navigationItem)
-        self.navigationController?.navigationBar.isHidden = true
+        self.navigationController?.initTransparentNavBar()
     }
     
     // MARK: - @IBAction Functions

--- a/popo/popo/Sources/ViewController/Onboarding/ConceptSelectViewController.swift
+++ b/popo/popo/Sources/ViewController/Onboarding/ConceptSelectViewController.swift
@@ -41,7 +41,7 @@ extension ConceptSelectViewController {
         subtitleLabel.font = UIFont.systemFont(ofSize: 18)
         subtitleLabel.textColor = #colorLiteral(red: 0.4784313725, green: 0.462745098, blue: 0.462745098, alpha: 1)
         
-        self.navigationController?.navigationBar.isHidden = true
+        self.navigationController?.initWithBackButton()
     }
     
     private func registerCell() {


### PR DESCRIPTION
### Description
- NavigationController Extension
- iOS15 대응 UINavigationBarAppearance 사용
- 투명 네비게이션 바
- 뒤로가기 + 완료버튼
- 뒤로가기 버튼
- 커스텀 버튼 1개
- 커스텀 버튼 2개

### 사용 예
```swift
self.navigationController?.initWithTwoCustomButtons(
            navigationItem: self.navigationItem,
            firstButtonImage: UIImage(systemName: "list.bullet")!,
            secondButtonImage: UIImage(systemName: "list.bullet")!,
            firstButtonClosure: #selector(touchDoneButton(_:)),
            secondButtonClosure: #selector(touchDoneButton(_:)))
```
```swift
@objc func touchDoneButton(_ sender: UIBarButtonItem) {
        print("done button clicked")
}
```

### Related Issue
close #22